### PR TITLE
fix: replace deprecated device_state_attributes() method

### DIFF
--- a/custom_components/thermal_vision/camera.py
+++ b/custom_components/thermal_vision/camera.py
@@ -203,7 +203,7 @@ class ThermalVisionCamera(Camera):
         return True
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the camera state attributes."""
         return {
             "fps": self._fps,

--- a/custom_components/thermal_vision/sensor.py
+++ b/custom_components/thermal_vision/sensor.py
@@ -191,7 +191,7 @@ class ThermalVisionSensor(Entity):
             return DEVICE_CLASS_TEMPERATURE
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Return the attributes of the sensor."""
         return {
             ATTR_AVG: self._average_temp,


### PR DESCRIPTION
This pull request replaces the deprecated ```device_state_attributes()``` method by the recommended ```extra_state_attributes()``` method according to the comment in https://github.com/home-assistant/core/blob/536d58968f86cccb0cb679523b0bbbed05ed2f6f/homeassistant/helpers/entity.py#L361

This will fix issue #136 and may also fix issue #123.